### PR TITLE
chore: use `ignore` wording & inline JSDoc types 

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -7,7 +7,7 @@ import type { EventData, EventPayload } from './types'
  */
 export function isFile(
   /** The current protocol */
-  protocol: string
+  protocol: string,
 ): boolean {
   return protocol === 'file:'
 }
@@ -21,7 +21,7 @@ export function isIgnored(
   /** The current hostname */
   hostname: string,
   /** Hostnames to ignore */
-  ignoredHostnames: string[]
+  ignoredHostnames: string[],
 ): boolean {
   return ignoredHostnames.includes(hostname)
 }
@@ -48,7 +48,7 @@ export function isUserSelfExcluded(): boolean {
  */
 export function createEventData(
   /** The event data */
-  data: Partial<EventData> = {}
+  data: Partial<EventData> = {},
 ): EventData {
   const { url, referrer, deviceWidth } = data
 
@@ -67,7 +67,7 @@ export function sendEvent(
   apiHost: string,
   /** The event payload */
   payload: EventPayload,
-  callback?: () => void
+  callback?: () => void,
 ) {
   return fetch(`${apiHost}/api/event`, {
     method: 'POST',

--- a/src/event.ts
+++ b/src/event.ts
@@ -3,31 +3,35 @@ import type { EventData, EventPayload } from './types'
 /**
  * Check if the protocol is file
  *
- * @param {string} protocol - The current protocol
- *
- * @returns {boolean} - If the protocol is file
+ * @returns - If the protocol is file
  */
-export function isFile(protocol: string): boolean {
+export function isFile(
+  /** The current protocol */
+  protocol: string
+): boolean {
   return protocol === 'file:'
 }
 
 /**
- * Check if the hostname is blacklisted
+ * Check if the hostname is ignored.
  *
- * @param hostname - The current hostname
- * @param blackListedHostnames - Hostnames to ignore
- * @returns - If the hostname is blacklisted
+ * @returns - If the hostname is ignored
  */
-export function isBlackListed(hostname: string, blackListedHostnames: string[]): boolean {
-  return blackListedHostnames.includes(hostname)
+export function isIgnored(
+  /** The current hostname */
+  hostname: string,
+  /** Hostnames to ignore */
+  ignoredHostnames: string[]
+): boolean {
+  return ignoredHostnames.includes(hostname)
 }
 
 /**
- * Check if the user exclude itself using localStorage
+ * Check if the user has excluded himself using `localStorage`.
  *
- * @returns - If the user exclude itself
+ * @returns - If the user exclude himself
  */
-export function isUserExcludeItself(): boolean {
+export function isUserSelfExcluded(): boolean {
   // If localStorage is not available, return false
   try {
     return localStorage.getItem('plausible_ignore') === 'true'
@@ -38,12 +42,14 @@ export function isUserExcludeItself(): boolean {
 }
 
 /**
- * Create the event data
+ * Create the event data.
  *
- * @param data - The event data
  * @returns - The event data
  */
-export function createEventData(data: Partial<EventData> = {}): EventData {
+export function createEventData(
+  /** The event data */
+  data: Partial<EventData> = {}
+): EventData {
   const { url, referrer, deviceWidth } = data
 
   return {
@@ -54,12 +60,15 @@ export function createEventData(data: Partial<EventData> = {}): EventData {
 }
 
 /**
- * Send an event to the API
- *
- * @param apiHost - The base API URL
- * @param payload - The event payload
+ * Send an event to the API.
  */
-export function sendEvent(apiHost: string, payload: EventPayload, callback?: () => void) {
+export function sendEvent(
+  /** The base API URL */
+  apiHost: string,
+  /** The event payload */
+  payload: EventPayload,
+  callback?: () => void
+) {
   return fetch(`${apiHost}/api/event`, {
     method: 'POST',
     headers: {

--- a/src/extensions/auto-outbound-tracking.ts
+++ b/src/extensions/auto-outbound-tracking.ts
@@ -11,11 +11,13 @@ export function useAutoOutboundTracking(plausible: Plausible, initOptions?: Even
 
   /**
    * Callback of an event listener on an anchor element.
-   *
-   * @param this - The anchor element
-   * @param event - The click event
    */
-  function handleLinkClickEvent(this: HTMLAnchorElement, event: MouseEvent) {
+  function handleLinkClickEvent(
+    /** The anchor element */
+    this: HTMLAnchorElement,
+     /** The click event */
+    event: MouseEvent
+  ) {
     const location = window.location as (Location & string) as string
     // If not left click and not middle click, do nothing.
     if ((event.type === 'auxclick' && event.button !== 1) || !isOutboundLink(this, location))
@@ -24,7 +26,7 @@ export function useAutoOutboundTracking(plausible: Plausible, initOptions?: Even
     // There is an href since it's an outbound link.
     const href = this.getAttribute('href')!
 
-    // Avoid to retrigger a navigation if trackEvent callback is called but setTimeout trigger at the same time.
+    // Avoid to retrigger a navigation if `trackEvent` callback is called but `setTimeout` trigger at the same time.
     let followedLink = false
 
     // Use arrow function to keep the context of `this` as the anchor element.
@@ -49,10 +51,11 @@ export function useAutoOutboundTracking(plausible: Plausible, initOptions?: Even
 
   /**
    * Add the event listeners to the node.
-   *
-   * @param node - The node to add
    */
-  function addNode(node: Node | ParentNode) {
+  function addNode(
+    /** The node to add */
+    node: Node | ParentNode
+  ) {
     if (node instanceof HTMLAnchorElement) {
       if (node.host !== location.host) {
         node.addEventListener('click', handleLinkClickEvent)
@@ -67,10 +70,11 @@ export function useAutoOutboundTracking(plausible: Plausible, initOptions?: Even
 
   /**
    * Remove the event listeners from the node.
-   *
-   * @param node - The node to remove
    */
-  function removeNode(node: Node | ParentNode) {
+  function removeNode(
+    /** The node to remove */
+    node: Node | ParentNode
+  ) {
     if (node instanceof HTMLAnchorElement) {
       node.removeEventListener('click', handleLinkClickEvent)
       node.removeEventListener('auxclick', handleLinkClickEvent)

--- a/src/extensions/auto-outbound-tracking.ts
+++ b/src/extensions/auto-outbound-tracking.ts
@@ -15,8 +15,8 @@ export function useAutoOutboundTracking(plausible: Plausible, initOptions?: Even
   function handleLinkClickEvent(
     /** The anchor element */
     this: HTMLAnchorElement,
-     /** The click event */
-    event: MouseEvent
+    /** The click event */
+    event: MouseEvent,
   ) {
     const location = window.location as (Location & string) as string
     // If not left click and not middle click, do nothing.
@@ -54,7 +54,7 @@ export function useAutoOutboundTracking(plausible: Plausible, initOptions?: Even
    */
   function addNode(
     /** The node to add */
-    node: Node | ParentNode
+    node: Node | ParentNode,
   ) {
     if (node instanceof HTMLAnchorElement) {
       if (node.host !== location.host) {
@@ -73,7 +73,7 @@ export function useAutoOutboundTracking(plausible: Plausible, initOptions?: Even
    */
   function removeNode(
     /** The node to remove */
-    node: Node | ParentNode
+    node: Node | ParentNode,
   ) {
     if (node instanceof HTMLAnchorElement) {
       node.removeEventListener('click', handleLinkClickEvent)

--- a/src/extensions/auto-pageviews.ts
+++ b/src/extensions/auto-pageviews.ts
@@ -8,7 +8,7 @@ export function useAutoPageviews(plausible: Plausible, initOptions?: EventOption
   }
 
   /**
-   * Encapsulate the pageview event to allow user to update the options at any time
+   * Encapsulate the pageview event to allow user to update the options at any time.
    */
   function page() {
     plausible.trackPageview(options)

--- a/src/extensions/file-downloads-tracking.ts
+++ b/src/extensions/file-downloads-tracking.ts
@@ -30,7 +30,7 @@ export function useAutoFileDownloadsTracking(plausible: Plausible, extensionOpti
     /** The anchor element */
     this: HTMLAnchorElement,
     /** The click event */
-    event: MouseEvent
+    event: MouseEvent,
   ) {
     // If not left click and not middle click, do nothing.
     if ((event.type === 'auxclick' && event.button !== 1))
@@ -68,7 +68,7 @@ export function useAutoFileDownloadsTracking(plausible: Plausible, extensionOpti
    */
   function addNode(
     /** The node to add */
-    node: Node | ParentNode
+    node: Node | ParentNode,
   ) {
     if (node instanceof HTMLAnchorElement) {
       // Downloaded files hosted on the same domain otherwise it's handled by the extension `useAutoOutboundTracking`.
@@ -88,7 +88,7 @@ export function useAutoFileDownloadsTracking(plausible: Plausible, extensionOpti
    */
   function removeNode(
     /** The node to remove */
-    node: Node | ParentNode
+    node: Node | ParentNode,
   ) {
     if (node instanceof HTMLAnchorElement) {
       node.removeEventListener('click', handleLinkClickEvent)

--- a/src/extensions/file-downloads-tracking.ts
+++ b/src/extensions/file-downloads-tracking.ts
@@ -25,11 +25,13 @@ export function useAutoFileDownloadsTracking(plausible: Plausible, extensionOpti
 
   /**
    * Callback of an event listener on an anchor element.
-   *
-   * @param this - The anchor element
-   * @param event - The click event
    */
-  function handleLinkClickEvent(this: HTMLAnchorElement, event: MouseEvent) {
+  function handleLinkClickEvent(
+    /** The anchor element */
+    this: HTMLAnchorElement,
+    /** The click event */
+    event: MouseEvent
+  ) {
     // If not left click and not middle click, do nothing.
     if ((event.type === 'auxclick' && event.button !== 1))
       return
@@ -63,10 +65,11 @@ export function useAutoFileDownloadsTracking(plausible: Plausible, extensionOpti
 
   /**
    * Add the event listeners to the node.
-   *
-   * @param node - The node to add
    */
-  function addNode(node: Node | ParentNode) {
+  function addNode(
+    /** The node to add */
+    node: Node | ParentNode
+  ) {
     if (node instanceof HTMLAnchorElement) {
       // Downloaded files hosted on the same domain otherwise it's handled by the extension `useAutoOutboundTracking`.
       if (node.host === location.host) {
@@ -82,10 +85,11 @@ export function useAutoFileDownloadsTracking(plausible: Plausible, extensionOpti
 
   /**
    * Remove the event listeners from the node.
-   *
-   * @param node - The node to remove
    */
-  function removeNode(node: Node | ParentNode) {
+  function removeNode(
+    /** The node to remove */
+    node: Node | ParentNode
+  ) {
     if (node instanceof HTMLAnchorElement) {
       node.removeEventListener('click', handleLinkClickEvent)
       node.removeEventListener('auxclick', handleLinkClickEvent)

--- a/src/plausible.ts
+++ b/src/plausible.ts
@@ -3,7 +3,7 @@
  * @see https://github.com/plausible/analytics/blob/master/tracker/src/customEvents.js#L77
  */
 
-import { sendEvent as _sendEvent, createEventData, isIgnored, isFile, isUserSelfExcluded } from './event'
+import { sendEvent as _sendEvent, createEventData, isFile, isIgnored, isUserSelfExcluded } from './event'
 import { createPayload } from './payload'
 import type { EventName, EventOptions, EventPayload, Plausible, PlausibleOptions } from './types'
 

--- a/src/plausible.ts
+++ b/src/plausible.ts
@@ -22,7 +22,7 @@ export function createPlausibleTracker(initOptions?: Partial<PlausibleOptions>) 
     hashMode: false,
     domain: location.hostname,
     apiHost: 'https://plausible.io',
-    blackListedDomains: ['localhost'],
+    ignoredHostnames: ['localhost'],
     logIgnored: false,
   }
 
@@ -41,8 +41,8 @@ export function createPlausibleTracker(initOptions?: Partial<PlausibleOptions>) 
     const data = createEventData(options?.data)
     const payload = createPayload(eventName, plausibleOptions, data, options)
 
-    // Ignore events if the protocol is file, the hostname is blacklisted or the user exclude itself.
-    if (isFile(protocol) || isIgnored(plausibleOptions.domain, plausibleOptions.blackListedDomains) || isUserSelfExcluded()) {
+    // Ignore events if the protocol is file, the hostname should be ignored or the user excluded himself.
+    if (isFile(protocol) || isIgnored(plausibleOptions.domain, plausibleOptions.ignoredHostnames) || isUserSelfExcluded()) {
       // Only log ignored events if the option is enabled.
       if (!plausibleOptions.logIgnored)
         // eslint-disable-next-line no-console

--- a/src/plausible.ts
+++ b/src/plausible.ts
@@ -3,7 +3,7 @@
  * @see https://github.com/plausible/analytics/blob/master/tracker/src/customEvents.js#L77
  */
 
-import { sendEvent as _sendEvent, createEventData, isBlackListed, isFile, isUserExcludeItself } from './event'
+import { sendEvent as _sendEvent, createEventData, isIgnored, isFile, isUserSelfExcluded } from './event'
 import { createPayload } from './payload'
 import type { EventName, EventOptions, EventPayload, Plausible, PlausibleOptions } from './types'
 
@@ -42,7 +42,7 @@ export function createPlausibleTracker(initOptions?: Partial<PlausibleOptions>) 
     const payload = createPayload(eventName, plausibleOptions, data, options)
 
     // Ignore events if the protocol is file, the hostname is blacklisted or the user exclude itself.
-    if (isFile(protocol) || isBlackListed(plausibleOptions.domain, plausibleOptions.blackListedDomains) || isUserExcludeItself()) {
+    if (isFile(protocol) || isIgnored(plausibleOptions.domain, plausibleOptions.blackListedDomains) || isUserSelfExcluded()) {
       // Only log ignored events if the option is enabled.
       if (!plausibleOptions.logIgnored)
         // eslint-disable-next-line no-console

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,7 @@ export interface PlausibleOptions {
    *
    * @default ['localhost']
    */
-  readonly blackListedDomains: string[]
+  readonly ignoredHostnames: string[]
   /**
    * Log events to the console when ignored.
    *


### PR DESCRIPTION
Closes #7

Changes:
- Inlines some JSDoc comments to make more use of TS features.
- Fixes a typo in a function: `isUserExcludeItself` 👉 `isUserSelfExcluded`