### PR TITLE
feat: add ecommerce tracking with revenue data

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -26,8 +26,9 @@
           <a href="https://plausible.io/docs/plausible-script" rel="noreferrer nofollow">Documentation (same page, noreferrer)</a>
         </li>
       </ul>
-        <button id="navigation">Click me (navigation event)</button>
+      <button id="navigation">Click me (navigation event)</button>
       <button id="btn">Click me (custom event)</button>
+      <button id="ecommerce">Click me (ecommerce revenue event)</button>
       <button id="cleanup">Cleanup</button>
       <ul>
         <li>

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -15,6 +15,10 @@ document.getElementById('btn')?.addEventListener('click', () => {
   plausible.trackEvent('click', { props: { btn: 'btn' } })
 })
 
+document.getElementById('ecommerce')?.addEventListener('click', () => {
+  plausible.trackEvent('Purchase', { revenue: { currency: 'USD', amount: '10.29' } })
+})
+
 // Use this to test the auto pageview tracking
 document.getElementById('navigation')?.addEventListener('click', () => {
   const url = new URL(location.href)

--- a/src/payload.ts
+++ b/src/payload.ts
@@ -9,6 +9,7 @@ export function createPayload(eventName: string, plausibleOptions: Required<Plau
     w: data.deviceWidth,
     h: plausibleOptions.hashMode ? 1 : 0,
     p: options && options.props ? JSON.stringify(options.props) : undefined,
+    $: options && options.revenue ? options.revenue : undefined,
   }
 
   return payload

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,7 +68,7 @@ export interface CallbackArgs {
   readonly status: number | null
 }
 
-export interface EventOptions extends EventProps {
+export interface EventOptions extends EventProps, EventRevenue {
   data?: Partial<EventData>
   /**
    * Callback to be called after the event is sent.
@@ -84,6 +84,25 @@ export interface EventProps {
    * Properties to be bound to the event.
    */
   readonly props?: { readonly [propName: string]: string | number | boolean }
+}
+
+/**
+ * Shape of the event revenue
+ */
+export interface EventRevenue {
+  /**
+   * Revenue data to be bound to the event.
+   */
+  readonly revenue?: {
+    /**
+     * The currency of the revenue (ISO 4217).
+     */
+    readonly currency: string
+    /**
+     * The amount of the revenue.
+     */
+    readonly amount: string | number
+  }
 }
 
 /**
@@ -123,4 +142,6 @@ export interface EventPayload {
   readonly w: Window['innerWidth']
   readonly h: 1 | 0
   readonly p?: string
+  readonly m?: string
+  readonly $?: EventRevenue['revenue']
 }


### PR DESCRIPTION
- Update payload.ts to include revenue in event payload
- Extend EventOptions interface in types.ts to support revenue
- Add ecommerce button and event listener in main.ts
- Update index.html to include ecommerce button